### PR TITLE
fix request and response typename bug.

### DIFF
--- a/sprotoparser.lua
+++ b/sprotoparser.lua
@@ -84,7 +84,7 @@ local typedef = P {
 	FIELD = namedpat("field", (name * blanks * tag * blank0 * ":" * blank0 * (C"*")^0 * typename * mainkey^0)),
 	STRUCT = P"{" * multipat(V"FIELD" + V"TYPE") * P"}",
 	TYPE = namedpat("type", P"." * name * blank0 * V"STRUCT" ),
-	SUBPROTO = Ct((C"request" + C"response") * blanks * (name + V"STRUCT")),
+	SUBPROTO = Ct((C"request" + C"response") * blanks * (typename + V"STRUCT")),
 	PROTOCOL = namedpat("protocol", name * blanks * tag * blank0 * P"{" * multipat(V"SUBPROTO") * P"}"),
 	ALL = multipat(V"TYPE" + V"PROTOCOL"),
 }
@@ -186,14 +186,27 @@ local function checktype(types, ptype, t)
 	end
 end
 
-local function check_protocoltag(r)
+local function check_protocol(r)
 	local map = {}
+	local type = r.type
 	for name, v in pairs(r.protocol) do
 		local tag = v.tag
+		local request = v.request
+		local response = v.response
 		local p = map[tag]
+		
 		if p then
-			error(string.format("redefined protocol tag %d at  `%s`.", tag, name))
+			error(string.format("redefined protocol tag %d at %s", tag, name))
 		end
+
+		if request and not type[request] then
+			error(string.format("Undefined request type %s in protocol %s", request, name))
+		end
+
+		if response and not type[response] then
+			error(string.format("Undefined response type %s in protocol %s", response, name))
+		end
+
 		map[tag] = v
 	end
 	return r
@@ -217,7 +230,7 @@ end
 local function parser(text,filename)
 	local state = { file = filename, pos = 0, line = 1 }
 	local r = lpeg.match(proto * -1 + exception , text , 1, state )
-	return flattypename(check_protocoltag(adjust(r)))
+	return flattypename(check_protocol(adjust(r)))
 end
 
 --[[


### PR DESCRIPTION
如下scheme:
```
.Test {
  .Internal {
    id 0 : integer
    name 1 : string    
  }
}

foorbar 1 {
  request Test.Internal
  response Test.Internal
}
```
将`request` 和`response` 文法中的`name`改成了`typename`，同时在`check_protocol`添加了对`type`的检查