### PR TITLE
fix #43 pack bug

### DIFF
--- a/lsproto.c
+++ b/lsproto.c
@@ -469,7 +469,7 @@ lpack(lua_State *L) {
 	size_t sz=0;
 	const void * buffer = getbuffer(L, 1, &sz);
 	// the worst-case space overhead of packing is 2 bytes per 2 KiB of input (256 words = 2KiB).
-	size_t maxsz = (sz + 2047) / 2048 * 2 + sz;
+	size_t maxsz = (sz + 2047) / 2048 * 2 + sz + 2;
 	void * output = lua_touserdata(L, lua_upvalueindex(1));
 	int bytes;
 	int osz = lua_tointeger(L, lua_upvalueindex(2));


### PR DESCRIPTION
测试用例如下：
~~~.lua
local data = {
    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 
    0x09,
}

core.pack(data)

--[[ output: 
    packing error, return size = 12
]]
~~~
计算`maxsz`的时候，需要先对`sz`进行下8字节对齐