### PR TITLE
适配windows编译

### DIFF
--- a/lsproto.c
+++ b/lsproto.c
@@ -673,7 +673,11 @@ ldefault(lua_State *L) {
 	return 1;
 }
 
+#ifdef _MSC_VER
+int __declspec(dllexport)
+#else
 int
+#endif
 luaopen_sproto_core(lua_State *L) {
 #ifdef luaL_checkversion
 	luaL_checkversion(L);

--- a/sproto.c
+++ b/sproto.c
@@ -180,9 +180,10 @@ import_string(struct sproto *s, const uint8_t * stream) {
 
 static int
 calc_pow(int base, int n) {
+	int r = 0;
 	if (n == 0)
 		return 1;
-	int r = calc_pow(base * base , n / 2);
+	r = calc_pow(base * base , n / 2);
 	if (n&1) {
 		r *= base;
 	}


### PR DESCRIPTION
为适配luaForWindows环境，需用vs2005编译，做了些修订：
1)增加dll导出函数，否则require找不到module;
2)vs早期c编译器似乎不支持变量在语句块中初始化