### PR TITLE
add required/optional property

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ The schema text is like this:
 
 .Person {	# . means a user defined type 
     name 0 : string	# string is a build-in type.
-    id 1 : integer
-    email 2 : string
+    id 1 : integer  [ required ]  # id is required, error if missing
+    email 2 : string  [ optional ]  # email is optional, if missing, using empty string instead
 
     .PhoneNumber {	# user defined type can be nest.
         number 0 : string
@@ -191,6 +191,7 @@ A schema text can be self-described by the sproto schema language.
         tag 3 : integer
         array 4	: boolean
         key 5 : integer # If key exists, array must be true, and it's a map.
+	required 6 : integer	# 1 (SPROTO_REQUIRED) 2 (SPROTO_OPTIONAL)
     }
     name 0 : string
     fields 1 : *field

--- a/sproto.h
+++ b/sproto.h
@@ -19,6 +19,9 @@ struct sproto_type;
 #define SPROTO_TSTRING_STRING 0
 #define SPROTO_TSTRING_BINARY 1
 
+#define SPROTO_REQUIRED 1
+#define SPROTO_OPTIONAL 2
+
 #define SPROTO_CB_ERROR -1
 #define SPROTO_CB_NIL -2
 #define SPROTO_CB_NOARRAY -3
@@ -48,6 +51,7 @@ struct sproto_arg {
 	int index;	// array base 1
 	int mainindex;	// for map
 	int extra; // SPROTO_TINTEGER: decimal ; SPROTO_TSTRING 0:utf8 string 1:binary
+	int required;
 };
 
 typedef int (*sproto_callback)(const struct sproto_arg *args);

--- a/test.lua
+++ b/test.lua
@@ -4,9 +4,9 @@ local print_r = require "print_r"
 
 local sp = sproto.parse [[
 .Person {
-	name 0 : string
+	name 0 : string [ required ]
 	id 1 : integer
-	email 2 : string
+	email 2 : string [ optional ]
 
 	.PhoneNumber {
 		number 0 : string
@@ -54,7 +54,8 @@ local ab = {
 			id = 30000,
 			phone = {
 				{ number = "9876543210" },
-			}
+			},
+			email = "",
 		},
 	}
 }


### PR DESCRIPTION
sproto迁移到cocos下 使用lua5.1 超过2^31时解析错误
原代码中为5.1版本实现的static lua_Integer lua_tointegerx(); 返回值就是一个32位的了
我做了一些修改 测试正常通过 
//.......encode(...);
// ...
case SPROTO_TINTEGER: {
		lua_Number v;
		lua_Number vh;
		lua_Number vn;

		if (lua_isnumber(L, -1)) {
			vn = lua_tonumber(L, -1);
		}
		else
		{
			return luaL_error(L, ".%s[%d] is not an integer (Is a %s)",
				args->tagname, args->index, lua_typename(L, lua_type(L, -1)));
		}

		if (args->extra) {
			v = vn * args->extra + 0.5;
		}
		else {
			v = (int64_t)vn;
		}
		lua_pop(L, 1);
		// notice: in lua 5.2, lua_Integer maybe 52bit
		vh = (int64_t)v >> 31;
		if (vh == 0 || vh == -1) {
			*(uint32_t *)args->value = (uint32_t)v;
			return 4;
		}
		else {
			*(uint64_t *)args->value = (uint64_t)v;
			return 8;
		}
	}