### PR TITLE
check redefine request and response

### DIFF
--- a/sprotoparser.lua
+++ b/sprotoparser.lua
@@ -97,7 +97,10 @@ local convert = {}
 function convert.protocol(all, obj)
 	local result = { tag = obj[2] }
 	for _, p in ipairs(obj[3]) do
-		assert(result[p[1]] == nil)
+		local pt = p[1]
+		if result[pt] ~= nil then
+			error(string.format("redefine %s in protocol %s", pt, obj[1]))
+		end
 		local typename = p[2]
 		if type(typename) == "table" then
 			local struct = typename


### PR DESCRIPTION
将在protocol中重复定义`request`或者`response`的错误信息，打印的更加详细。