### PR TITLE
support weak type for sproto

### DIFF
--- a/lsproto.c
+++ b/lsproto.c
@@ -81,6 +81,54 @@ lua_seti(lua_State *L, int index, lua_Integer n) {
 
 #endif
 
+#if defined(SPROTO_WEAK_TYPE)
+static int64_t
+tointegerx (lua_State *L, int idx, int *isnum) {
+	int64_t v;
+	if (lua_isnumber(L, idx)) {
+		v = (int64_t)(round(lua_tonumber(L, idx)));
+		if (isnum) *isnum = 1;
+		return v;
+	} else {
+		return lua_tointegerx(L, idx, isnum);
+	}
+}
+
+static int
+tobooleanx (lua_State *L, int idx, int *isbool) {
+	if (isbool) *isbool = 1;
+	return lua_toboolean(L, idx);
+}
+
+static const char *
+tolstringx (lua_State *L, int idx, size_t *len, int *isstring) {
+	const char * str = lua_tolstring(L, idx, len);
+	if (isstring) {
+		*isstring = (str != NULL);
+	}
+	return str;
+}
+
+#else
+#define tointegerx(L, idx, isnum) lua_tointegerx((L), (idx), (isnum))
+
+static int
+tobooleanx (lua_State *L, int idx, int *isbool) {
+	if (isbool) *isbool = lua_isboolean(L, idx);
+	return lua_toboolean(L, idx);
+}
+
+static const char *
+tolstringx (lua_State *L, int idx, size_t *len, int *isstring) {
+	if (isstring) {
+		*isstring = (lua_type(L, idx) == LUA_TSTRING);
+	}
+	const char * str = lua_tolstring(L, idx, len);
+	return str;
+}
+
+#endif
+
 static int
 lnewproto(lua_State *L) {
 	struct sproto * sp;
@@ -243,7 +291,7 @@ encode_one(const struct sproto_arg *args, struct encode_ud *self) {
 			// use 64bit integer for 32bit architecture.
 			v = (int64_t)(round(vn * args->extra));
 		} else {
-			v = lua_tointegerx(L, -1, &isnum);
+			v = tointegerx(L, -1, &isnum);
 			if(!isnum) {
 				return luaL_error(L, ".%s[%d] is not an integer (Is a %s)", 
 					args->tagname, args->index, lua_typename(L, lua_type(L, -1)));
@@ -267,8 +315,9 @@ encode_one(const struct sproto_arg *args, struct encode_ud *self) {
 		return 8;
 	}
 	case SPROTO_TBOOLEAN: {
-		int v = lua_toboolean(L, -1);
-		if (!lua_isboolean(L,-1)) {
+		int isbool;
+		int v = tobooleanx(L, -1, &isbool);
+		if (!isbool) {
 			return luaL_error(L, ".%s[%d] is not a boolean (Is a %s)",
 				args->tagname, args->index, lua_typename(L, lua_type(L, -1)));
 		}
@@ -278,12 +327,12 @@ encode_one(const struct sproto_arg *args, struct encode_ud *self) {
 	}
 	case SPROTO_TSTRING: {
 		size_t sz = 0;
-		const char * str;
-		if (!lua_isstring(L, -1)) {
+		int isstring;
+		int type = lua_type(L, -1); // get the type firstly, lua_tolstring may convert value on stack to string
+		const char * str = tolstringx(L, -1, &sz, &isstring);
+		if (!isstring) {
 			return luaL_error(L, ".%s[%d] is not a string (Is a %s)", 
-				args->tagname, args->index, lua_typename(L, lua_type(L, -1)));
-		} else {
-			str = lua_tolstring(L, -1, &sz);
+				args->tagname, args->index, lua_typename(L, type));
 		}
 		if (sz > args->length)
 			return SPROTO_CB_ERROR;

--- a/lsproto.c
+++ b/lsproto.c
@@ -102,10 +102,11 @@ tobooleanx (lua_State *L, int idx, int *isbool) {
 
 static const char *
 tolstringx (lua_State *L, int idx, size_t *len, int *isstring) {
-	const char * str = lua_tolstring(L, idx, len);
+	const char * str = luaL_tolstring(L, idx, len); // call metamethod, '__tostring' must return a string
 	if (isstring) {
-		*isstring = (str != NULL);
+		*isstring = 1;
 	}
+	lua_pop(L, 1);
 	return str;
 }
 

--- a/testall.lua
+++ b/testall.lua
@@ -68,8 +68,8 @@ local obj = {
 	k = 12.34567,
 	l = {11.1, 22.2, 33.3, 44.4},
 	m = {
-		a = {a = 1, b = false, c = 5, d = 6},
-		c = {a = 2, b = true, c = 6, d = 7},
+		a = {a = "str1", b = false, c = 5, d = 6},
+		c = {a = "str2", b = true, c = 6, d = 7},
 	}
 }
 

--- a/testweaktype.lua
+++ b/testweaktype.lua
@@ -1,0 +1,35 @@
+local sproto = require "sproto"
+
+local print_r = require "print_r"
+
+local wt = sproto.parse [[
+.foo {
+    s 0: string
+    i 1: integer
+    b 2: boolean
+}
+]]
+
+local t
+
+t = {s = "abc"}
+print_r(wt:decode("foo", wt:encode("foo", t)))
+
+t = {s = 123}
+print_r(wt:decode("foo", wt:encode("foo", t)))
+
+t = {s = setmetatable({}, {__tostring = function() return "hello" end})}
+print_r(wt:decode("foo", wt:encode("foo", t)))
+
+t = {i = 100}
+print_r(wt:decode("foo", wt:encode("foo", t)))
+
+t = {i = 100.1}
+print_r(wt:decode("foo", wt:encode("foo", t)))
+
+t = {b = true}
+print_r(wt:decode("foo", wt:encode("foo", t)))
+
+t = {b = {}}
+print_r(wt:decode("foo", wt:encode("foo", t)))
+


### PR DESCRIPTION
增加了 `SPROTO_WEAK_TYPE` 宏，希望能在 sproto 中支持弱类型开启与否，放松类型校验。

起因是项目组中出现把 number 值赋值给了 sproto integer 类型，导致报错。测试时未能暴露，出错的时候已经是在线上环境，造成影响比较大。

如果单纯直接放松检查，我觉得不太可取。结合 lua 的几个 api 考虑了下，增加宏开关使得 sproto 放松类型校验。
原来的情况是这样的：
1. sproto integer 仅接受 lua integer。
2. sproto boolean 仅接受 lua boolean。
3. sproto string 可接受 string 值或任何可转为 string 的值。（不知道这里是否故意还是原来实现有问题，number 值也可以正常 encode）

开启 `SPROTO_WEAK_TYPE` 宏后，行为同 lua_toxxx 一致：
1. sproto integer 可接受 lua integer 或 lua number。
2. sproto boolean 为 false 仅当 lua 值为 false 或 nil。
3. sproto string 可接受 string 值或任何可转为 string 的值。（同时对于宏未开启时，改为仅接受 string 值。）

麻烦云风看一下，或者看是否有其他建议。谢谢。