### PR TITLE
修复tointegerx对int64的精度问题

### DIFF
--- a/lsproto.c
+++ b/lsproto.c
@@ -84,14 +84,16 @@ lua_seti(lua_State *L, int index, lua_Integer n) {
 #if defined(SPROTO_WEAK_TYPE)
 static int64_t
 tointegerx (lua_State *L, int idx, int *isnum) {
-	int64_t v;
-	if (lua_isnumber(L, idx)) {
-		v = (int64_t)(round(lua_tonumber(L, idx)));
-		if (isnum) *isnum = 1;
-		return v;
-	} else {
-		return lua_tointegerx(L, idx, isnum);
+	int _isnum = 0;
+	int64_t v = lua_tointegerx(L, idx, &_isnum);
+	if (!_isnum){
+		double num = lua_tonumberx(L, idx, &_isnum);
+		if(_isnum) {
+			v = (int64_t)llround(num);
+		}
 	}
+	if(isnum) *isnum = _isnum;
+	return v;
 }
 
 static int


### PR DESCRIPTION
由于double的有效位为15-16位，当打开`SPROTO_WEAK_TYPE` 时，传入一个过大的integer值`8589934596294967518`进行encode，decode会出来一个错误的值`8589934596294967296` 。

-------

现在改为：
1. 优先判断是否是integer。
2. 如果不是integer，再进行round转换。

@t0350 看下这样实现合适不？